### PR TITLE
add drug_type_concept_id from drug_exposure to indexes

### DIFF
--- a/sql/indexes_emr.sqlite.sql
+++ b/sql/indexes_emr.sqlite.sql
@@ -16,6 +16,7 @@ create index idx_cond_occur__dt on condition_occurrence (condition_start_date);
 -- drug_exposure
 create index idx_drug_exp__pt on drug_exposure (person_id);
 create index idx_drug_exp__id on drug_exposure (drug_concept_id);
+create index idx_drug_ex__dtc_id on drug_exposure (drug_type_concept_id); 
 create index idx_drug_exp__dt on drug_exposure (drug_exposure_start_date);
 
 -- measurement

--- a/sql/indexes_emr.sqlite.sql
+++ b/sql/indexes_emr.sqlite.sql
@@ -16,7 +16,7 @@ create index idx_cond_occur__dt on condition_occurrence (condition_start_date);
 -- drug_exposure
 create index idx_drug_exp__pt on drug_exposure (person_id);
 create index idx_drug_exp__id on drug_exposure (drug_concept_id);
-create index idx_drug_ex__dtc_id on drug_exposure (drug_type_concept_id); 
+create index idx_drug_exp__type_id on drug_exposure (drug_type_concept_id); 
 create index idx_drug_exp__dt on drug_exposure (drug_exposure_start_date);
 
 -- measurement


### PR DESCRIPTION
I added drug_type_concept_id to the list of indexes for the drug_exposure table.  The field is useful for determining the origin of a drug exposure as 'prescription written', 'medication list entry', etc.  I have been running queries using this field as a filter and am running into long execution times.  I'm hoping addition of this index will help speed things up a bit.