### PR TITLE
added --re-interval to awk in line 65.  some GNU awk versions appear …

### DIFF
--- a/bash/clean_sort_compress_data.sh
+++ b/bash/clean_sort_compress_data.sh
@@ -62,7 +62,7 @@ for file in $(find ${src_dir} -maxdepth 1 -iname 'omop_*.csv' -not -iname '*no_q
         # Change to Unix EOLs (delete "CR" from "CRLF"; `dos2unix`
         # doesn't work as a filter) and clean the fields.  Then sort by
         # patient ID.
-        ${timer_cmd} sed -e 's/\r//g' ${sub_dblqt} ${file} | ${timer_cmd} awk -F , -f ${script_dir}/clean_data.awk | ${timer_cmd} sort --stable --field-separator=, --buffer-size=10G --temporary-directory=${TMPDIR} --key=${key} > ${dst_file}
+        ${timer_cmd} sed -e 's/\r//g' ${sub_dblqt} ${file} | ${timer_cmd} awk -F , -f ${script_dir}/clean_data.awk --re-interval | ${timer_cmd} sort --stable --field-separator=, --buffer-size=10G --temporary-directory=${TMPDIR} --key=${key} > ${dst_file}
         log "Done cleaning and sorting '${file}'"
         # Compress in various ways to allow for different size /
         # decompress speed trade-offs.  Do all compression in parallel.


### PR DESCRIPTION
@afbarnard I added --re-interval to the data cleaning step of awk.  When I tried cleaning the most recent version of the OMOP files the dates remained unchanged.  After doing a little digging it looks like some GNU versions of awk don't allow {} syntax in their regex.  Adding --re-interval seems to fix the problem.  Cheers, Jon